### PR TITLE
extract_files.sh needs --path option

### DIFF
--- a/pages/extracting_blobs_from_zips.md
+++ b/pages/extracting_blobs_from_zips.md
@@ -47,7 +47,7 @@ sudo mount system.img system/
 After you have mounted the image, move to the root directory of the sources of your device and run `extract-files.sh` as follows:
 
 ```
-./extract-files.sh ~/android/system_dump/
+./extract-files.sh --path ~/android/system_dump/
 ```
 This will tell `extract-files.sh` to get the files from the mounted system dump rather than from a connected device.
 
@@ -77,7 +77,7 @@ where `path/to/` is the path to the installable zip.
 After you have extracted the `system` folder, move to the root directory of the sources of your device and run `extract-files.sh` as follows:
 
 ```
-./extract-files.sh ~/android/system_dump/
+./extract-files.sh --path ~/android/system_dump/
 ```
 This will tell `extract-files.sh` to get the files from the extracted system dump rather than from a connected device.
 


### PR DESCRIPTION
in newer versions of extract_files.sh, at least for cheeseburger (and hopefully for other devices, too), the script needs the --path option in order to make it extract the blobs from the given path.

if this option (--path) is only used in some of the extract_files scripts, we might need to explain that sometimes the option is required and sometimes it is not?!